### PR TITLE
textproc/opensearch: Update to 2.8.0

### DIFF
--- a/textproc/opensearch-dashboards/Makefile
+++ b/textproc/opensearch-dashboards/Makefile
@@ -13,8 +13,6 @@ LICENSE_FILE=	${WRKSRC}/LICENSE.txt
 
 BUILD_DEPENDS=	npm-node16>0:www/npm-node16
 
-CONFLICTS=	opensearch-dashboard13
-
 USES=		nodejs:16,build,run python:build
 USE_RC_SUBR=	${PORTNAME}
 

--- a/textproc/opensearch-dashboards/Makefile
+++ b/textproc/opensearch-dashboards/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	opensearch-dashboards
-DISTVERSION=	2.7.0
+DISTVERSION=	2.8.0
 DISTVERSIONSUFFIX=	-linux-x64
 CATEGORIES=	textproc www
 MASTER_SITES=	https://artifacts.opensearch.org/releases/bundle/${PORTNAME}/${DISTVERSION}/

--- a/textproc/opensearch-dashboards/distinfo
+++ b/textproc/opensearch-dashboards/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1684548918
-SHA256 (opensearch-dashboards-2.7.0-linux-x64.tar.gz) = a93665de8035ef616c1d4fcfaffc0cfc63a590b3852cd9f54a0009823b03328a
-SIZE (opensearch-dashboards-2.7.0-linux-x64.tar.gz) = 275618492
+TIMESTAMP = 1686119539
+SHA256 (opensearch-dashboards-2.8.0-linux-x64.tar.gz) = 11a77a4ad7c574d97fbfbce619e3f285e0553ffc4a009de6a08eb3e99bc4370f
+SIZE (opensearch-dashboards-2.8.0-linux-x64.tar.gz) = 306279161

--- a/textproc/opensearch/Makefile
+++ b/textproc/opensearch/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	opensearch
-DISTVERSION=	2.7.0
+DISTVERSION=	2.8.0
 DISTVERSIONSUFFIX=	-linux-x64
 CATEGORIES=	textproc java devel
 MASTER_SITES=	https://artifacts.opensearch.org/releases/bundle/${PORTNAME}/${DISTVERSION}/

--- a/textproc/opensearch/distinfo
+++ b/textproc/opensearch/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1684548868
-SHA256 (opensearch-2.7.0-linux-x64.tar.gz) = aa086a15cc1f183b4a572256dc76fd01df143e1d9d7e1cf1c320993a9ee61a63
-SIZE (opensearch-2.7.0-linux-x64.tar.gz) = 750369026
+TIMESTAMP = 1686119536
+SHA256 (opensearch-2.8.0-linux-x64.tar.gz) = eb8bd68acf9841f8cec3c79a622d67820abf43612baaa704b884973c644eca97
+SIZE (opensearch-2.8.0-linux-x64.tar.gz) = 744285401


### PR DESCRIPTION
### 2023-06-06

I just started to update ports, started the build but have not tested yet.

### 2023-06-07

OpenSearch and OpenSearch-Dashboard start. Older dashboards / visualizations are not shown. Importing them seems to fail.  Not sure why.