### PR TITLE
textproc/opensearch13: Update to 1.3.11

### DIFF
--- a/textproc/opensearch13/Makefile
+++ b/textproc/opensearch13/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	opensearch
-DISTVERSION=	1.3.10
+DISTVERSION=	1.3.11
 DISTVERSIONSUFFIX=	-linux-x64
 CATEGORIES=	textproc java devel
 MASTER_SITES=	https://artifacts.opensearch.org/releases/bundle/${PORTNAME}/${DISTVERSION}/

--- a/textproc/opensearch13/distinfo
+++ b/textproc/opensearch13/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1684548989
-SHA256 (opensearch-1.3.10-linux-x64.tar.gz) = 711ab9c465a2782a236763bbcdb0e16b5d0cc97c01f0a533e8a5bcfce4df79f4
-SIZE (opensearch-1.3.10-linux-x64.tar.gz) = 423540454
+TIMESTAMP = 1688162487
+SHA256 (opensearch-1.3.11-linux-x64.tar.gz) = 0c0968ebe64b4360ba9ae12475c836c48c4bdfd2ac45ec86b87128566c47f089
+SIZE (opensearch-1.3.11-linux-x64.tar.gz) = 434898265


### PR DESCRIPTION
Release notes:
https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-1.3.11.md

With hat:	opensearch